### PR TITLE
CSV Linter 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,15 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Run csv-lint
+      uses: blackstar257/docker-csvlint@master
+      env:
+        ACTION_STATE_NAME: "_data/companies.csv"


### PR DESCRIPTION
Threw together a simple github action linter for the csv file. I noticed the last two builds failed due to spaces in the csv file. 