### PR TITLE
Add Patreon to company list

### DIFF
--- a/_data/companies.csv
+++ b/_data/companies.csv
@@ -138,6 +138,7 @@ name,url,comment
 "OpenTable","https://www.opentable.com/legal/privacy-policy-additional-disclosures-california",""
 "Pacific Gas & Electric","https://pgeipaprod.service-now.com/privacy_consumer",""
 "Papa John's","https://www.papajohns.com/privacy-policy.html","(Your California privacy rights.)"
+"Patreon","https://privacy.patreon.com/policies?modal=take-control#compliance-with-california-privacy-laws",""
 "Paypal","https://www.paypal.com/us/smarthelp/contact-us?email=privacy",""
 "Peloton","https://www.onepeloton.com/california-privacy-notice",""
 "Petco","https://dsar.oncentrl.com/petco_rightsrequest.html",""


### PR DESCRIPTION
The URL provided is the tool that allows users to download or delete their data. Beneath the modal dialog is the CCPA section of the Privacy Policy.